### PR TITLE
Enable cascade delete for customer invoice relationships

### DIFF
--- a/ErpSystemBeniSouef.Infrastructer/Data/Context/ApplicationDbContext.cs
+++ b/ErpSystemBeniSouef.Infrastructer/Data/Context/ApplicationDbContext.cs
@@ -99,19 +99,54 @@ namespace ErpSystemBeniSouef.Infrastructer.Data.Context
 
             #region Edit Data Region
 
+            // Enable Cascade Delete for Customer -> CustomerInvoice
+            builder.Entity<CustomerInvoice>()
+                .HasOne(i => i.Customer)
+                .WithMany(c => c.Invoices)
+                .HasForeignKey(i => i.CustomerId)
+                .OnDelete(DeleteBehavior.Cascade);
 
-            //     builder.Entity<Product>()
-            //     .HasOne(p => p.Company)
-            //     .WithMany(c => c.Products)
-            //     .HasForeignKey(p => p.CompanyId)
-            //     .OnDelete(DeleteBehavior.SetNull); // 👈 بدل Cascade
+            // Enable Cascade Delete for CustomerInvoice -> CustomerInvoiceItems
+            builder.Entity<CustomerInvoiceItems>()
+                .HasOne(i => i.Invoice)
+                .WithMany(inv => inv.Items)
+                .HasForeignKey(i => i.InvoiceId)
+                .OnDelete(DeleteBehavior.Cascade);
 
+            // Enable Cascade Delete for CustomerInvoice -> InstallmentPlan
+            builder.Entity<InstallmentPlan>()
+                .HasOne(p => p.Invoice)
+                .WithMany(inv => inv.Installments)
+                .HasForeignKey(p => p.InvoiceId)
+                .OnDelete(DeleteBehavior.Cascade);
 
-            //     builder.Entity<Category>()
-            //.HasOne(c => c.Company)
-            //.WithMany()
-            //.HasForeignKey(c => c.CompanyId)
-            //.OnDelete(DeleteBehavior.Cascade); // تسيبها زي ما هي
+            // Enable Cascade Delete for CustomerInvoice -> MonthlyInstallment
+            builder.Entity<MonthlyInstallment>()
+                .HasOne(m => m.Invoice)
+                .WithMany()
+                .HasForeignKey(m => m.InvoiceId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // Enable Cascade Delete for CustomerInvoiceItems -> Commission
+            builder.Entity<Commission>()
+                .HasOne(c => c.InvoiceItem)
+                .WithMany()
+                .HasForeignKey(c => c.InvoiceItemId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // another database Cascade here to prevent SQL Server Multiple Cascade Path errors.
+            builder.Entity<Commission>()
+                .HasOne(c => c.Invoice)
+                .WithMany()
+                .HasForeignKey(c => c.InvoiceId)
+                .OnDelete(DeleteBehavior.ClientCascade);
+
+            // Enable Cascade Delete for CustomerInvoice -> Discount
+            builder.Entity<Discount>()
+                .HasOne(d => d.Invoice)
+                .WithMany()
+                .HasForeignKey(d => d.InvoiceId)
+                .OnDelete(DeleteBehavior.Cascade);
 
             #endregion
 

--- a/ErpSystemBeniSouef.Infrastructer/Migrations/20260304225532_addOnDeleteCascadeForCustomerInvoices.Designer.cs
+++ b/ErpSystemBeniSouef.Infrastructer/Migrations/20260304225532_addOnDeleteCascadeForCustomerInvoices.Designer.cs
@@ -4,6 +4,7 @@ using ErpSystemBeniSouef.Infrastructer.Data.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace ErpSystemBeniSouef.Infrastructer.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260304225532_addOnDeleteCascadeForCustomerInvoices")]
+    partial class addOnDeleteCascadeForCustomerInvoices
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1375,13 +1378,13 @@ namespace ErpSystemBeniSouef.Infrastructer.Migrations
                     b.HasOne("ErpSystemBeniSouef.Core.Entities.CustomerInvoices.CustomerInvoice", "Invoice")
                         .WithMany()
                         .HasForeignKey("InvoiceId")
-                        .OnDelete(DeleteBehavior.ClientCascade)
+                        .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
                     b.HasOne("ErpSystemBeniSouef.Core.Entities.CustomerInvoices.CustomerInvoiceItems", "InvoiceItem")
                         .WithMany()
                         .HasForeignKey("InvoiceItemId")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.HasOne("ErpSystemBeniSouef.Core.Entities.Product", "Product")

--- a/ErpSystemBeniSouef.Infrastructer/Migrations/20260304225532_addOnDeleteCascadeForCustomerInvoices.cs
+++ b/ErpSystemBeniSouef.Infrastructer/Migrations/20260304225532_addOnDeleteCascadeForCustomerInvoices.cs
@@ -1,0 +1,162 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ErpSystemBeniSouef.Infrastructer.Migrations
+{
+    /// <inheritdoc />
+    public partial class addOnDeleteCascadeForCustomerInvoices : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Commissions_customerInvoices_InvoiceId",
+                table: "Commissions");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_customerInvoiceItems_customerInvoices_InvoiceId",
+                table: "customerInvoiceItems");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_customerInvoices_Customer_CustomerId",
+                table: "customerInvoices");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Discount_customerInvoices_InvoiceId",
+                table: "Discount");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_installmentPlans_customerInvoices_InvoiceId",
+                table: "installmentPlans");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_MonthlyInstallment_customerInvoices_InvoiceId",
+                table: "MonthlyInstallment");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Commissions_customerInvoices_InvoiceId",
+                table: "Commissions",
+                column: "InvoiceId",
+                principalTable: "customerInvoices",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_customerInvoiceItems_customerInvoices_InvoiceId",
+                table: "customerInvoiceItems",
+                column: "InvoiceId",
+                principalTable: "customerInvoices",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_customerInvoices_Customer_CustomerId",
+                table: "customerInvoices",
+                column: "CustomerId",
+                principalTable: "Customer",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Discount_customerInvoices_InvoiceId",
+                table: "Discount",
+                column: "InvoiceId",
+                principalTable: "customerInvoices",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_installmentPlans_customerInvoices_InvoiceId",
+                table: "installmentPlans",
+                column: "InvoiceId",
+                principalTable: "customerInvoices",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MonthlyInstallment_customerInvoices_InvoiceId",
+                table: "MonthlyInstallment",
+                column: "InvoiceId",
+                principalTable: "customerInvoices",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Commissions_customerInvoices_InvoiceId",
+                table: "Commissions");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_customerInvoiceItems_customerInvoices_InvoiceId",
+                table: "customerInvoiceItems");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_customerInvoices_Customer_CustomerId",
+                table: "customerInvoices");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Discount_customerInvoices_InvoiceId",
+                table: "Discount");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_installmentPlans_customerInvoices_InvoiceId",
+                table: "installmentPlans");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_MonthlyInstallment_customerInvoices_InvoiceId",
+                table: "MonthlyInstallment");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Commissions_customerInvoices_InvoiceId",
+                table: "Commissions",
+                column: "InvoiceId",
+                principalTable: "customerInvoices",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_customerInvoiceItems_customerInvoices_InvoiceId",
+                table: "customerInvoiceItems",
+                column: "InvoiceId",
+                principalTable: "customerInvoices",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_customerInvoices_Customer_CustomerId",
+                table: "customerInvoices",
+                column: "CustomerId",
+                principalTable: "Customer",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Discount_customerInvoices_InvoiceId",
+                table: "Discount",
+                column: "InvoiceId",
+                principalTable: "customerInvoices",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_installmentPlans_customerInvoices_InvoiceId",
+                table: "installmentPlans",
+                column: "InvoiceId",
+                principalTable: "customerInvoices",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MonthlyInstallment_customerInvoices_InvoiceId",
+                table: "MonthlyInstallment",
+                column: "InvoiceId",
+                principalTable: "customerInvoices",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/ErpSystemBeniSouef.Infrastructer/Migrations/20260304225918_AddCommissionCascadeDelete.Designer.cs
+++ b/ErpSystemBeniSouef.Infrastructer/Migrations/20260304225918_AddCommissionCascadeDelete.Designer.cs
@@ -4,6 +4,7 @@ using ErpSystemBeniSouef.Infrastructer.Data.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace ErpSystemBeniSouef.Infrastructer.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260304225918_AddCommissionCascadeDelete")]
+    partial class AddCommissionCascadeDelete
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1375,7 +1378,7 @@ namespace ErpSystemBeniSouef.Infrastructer.Migrations
                     b.HasOne("ErpSystemBeniSouef.Core.Entities.CustomerInvoices.CustomerInvoice", "Invoice")
                         .WithMany()
                         .HasForeignKey("InvoiceId")
-                        .OnDelete(DeleteBehavior.ClientCascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.HasOne("ErpSystemBeniSouef.Core.Entities.CustomerInvoices.CustomerInvoiceItems", "InvoiceItem")

--- a/ErpSystemBeniSouef.Infrastructer/Migrations/20260304225918_AddCommissionCascadeDelete.cs
+++ b/ErpSystemBeniSouef.Infrastructer/Migrations/20260304225918_AddCommissionCascadeDelete.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ErpSystemBeniSouef.Infrastructer.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCommissionCascadeDelete : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Commissions_customerInvoiceItems_InvoiceItemId",
+                table: "Commissions");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Commissions_customerInvoices_InvoiceId",
+                table: "Commissions");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Commissions_customerInvoiceItems_InvoiceItemId",
+                table: "Commissions",
+                column: "InvoiceItemId",
+                principalTable: "customerInvoiceItems",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Commissions_customerInvoices_InvoiceId",
+                table: "Commissions",
+                column: "InvoiceId",
+                principalTable: "customerInvoices",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Commissions_customerInvoiceItems_InvoiceItemId",
+                table: "Commissions");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Commissions_customerInvoices_InvoiceId",
+                table: "Commissions");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Commissions_customerInvoiceItems_InvoiceItemId",
+                table: "Commissions",
+                column: "InvoiceItemId",
+                principalTable: "customerInvoiceItems",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Commissions_customerInvoices_InvoiceId",
+                table: "Commissions",
+                column: "InvoiceId",
+                principalTable: "customerInvoices",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/ErpSystemBeniSouef.Infrastructer/Migrations/20260304230409_AddCommissionCascadeDeleteInvoice.Designer.cs
+++ b/ErpSystemBeniSouef.Infrastructer/Migrations/20260304230409_AddCommissionCascadeDeleteInvoice.Designer.cs
@@ -4,6 +4,7 @@ using ErpSystemBeniSouef.Infrastructer.Data.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace ErpSystemBeniSouef.Infrastructer.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260304230409_AddCommissionCascadeDeleteInvoice")]
+    partial class AddCommissionCascadeDeleteInvoice
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ErpSystemBeniSouef.Infrastructer/Migrations/20260304230409_AddCommissionCascadeDeleteInvoice.cs
+++ b/ErpSystemBeniSouef.Infrastructer/Migrations/20260304230409_AddCommissionCascadeDeleteInvoice.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ErpSystemBeniSouef.Infrastructer.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCommissionCascadeDeleteInvoice : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Commissions_customerInvoices_InvoiceId",
+                table: "Commissions");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Commissions_customerInvoices_InvoiceId",
+                table: "Commissions",
+                column: "InvoiceId",
+                principalTable: "customerInvoices",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Commissions_customerInvoices_InvoiceId",
+                table: "Commissions");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Commissions_customerInvoices_InvoiceId",
+                table: "Commissions",
+                column: "InvoiceId",
+                principalTable: "customerInvoices",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/ErpSystemBeniSouef.Service/CustomerInvoiceServices/CustomerInvoiceService.cs
+++ b/ErpSystemBeniSouef.Service/CustomerInvoiceServices/CustomerInvoiceService.cs
@@ -110,6 +110,8 @@ namespace ErpSystemBeniSouef.Service.CustomerInvoiceServices
                     await CreateCommissionRecordAsync(representative.Id, invoice.Id, product, item.Quantity, invoice.InvoiceDate, invoiceItem.Id);
                 }
 
+                var startDate = dto.FirstInvoiceDate;
+
                 //  Create installment plans
                 foreach (var inst in dto.installmentsdtos)
                 {
@@ -128,8 +130,8 @@ namespace ErpSystemBeniSouef.Service.CustomerInvoiceServices
                         .OrderByDescending(m => m.MonthDate)
                         .FirstOrDefault();
 
-                    var startDate = lastInstallment is null
-                        ? invoice.InvoiceDate.AddMonths(1)
+                    startDate = lastInstallment is null
+                        ? dto.FirstInvoiceDate
                         : lastInstallment.MonthDate.AddMonths(1);
 
                     await GenerateMonthlyInstallmentsAsync(invoice, inst.NumberOfMonths, inst.Amount, startDate);
@@ -281,11 +283,10 @@ namespace ErpSystemBeniSouef.Service.CustomerInvoiceServices
             try
             {
                 var customer = await _unitOfWork.Repository<Customer>()
-                    .GetAllQueryable()
-                    .Include(c => c.Invoices)
-                        .ThenInclude(i => i.Items)
-                            .ThenInclude(it => it.Product)
-                    .FirstOrDefaultAsync(c => c.Id == customerId);
+                    .GetByIdWithIncludeAsync(customerId, q => q
+                        .Include(c => c.Invoices)
+                            .ThenInclude(i => i.Items)
+                                .ThenInclude(it => it.Product));
 
                 if (customer == null)
                     return ServiceResponse<bool>.Failure("Customer not found.");
@@ -348,11 +349,7 @@ namespace ErpSystemBeniSouef.Service.CustomerInvoiceServices
                     //  Remove monthly installments and plans related to this invoice
                    
                     var monthlyInstallments = await _unitOfWork.Repository<MonthlyInstallment>()
-                        .GetAllAsync(m => m.InvoiceId == invoice.Id);
-
-
-                    //var monthlyInstallments = await _unitOfWork.Repository<MonthlyInstallment>()
-                    //    .GetByCondionAndInclideAsync(m => m.InvoiceId == invoice.Id);
+                        .GetByCondionAndInclideAsync(m => m.InvoiceId == invoice.Id);
 
                     if (monthlyInstallments != null && monthlyInstallments.Any())
                     {
@@ -361,11 +358,7 @@ namespace ErpSystemBeniSouef.Service.CustomerInvoiceServices
                     }
 
                     var installmentPlans = await _unitOfWork.Repository<InstallmentPlan>()
-                        .GetAllAsync(p => p.InvoiceId == invoice.Id);
-
-
-                    //var installmentPlans = await _unitOfWork.Repository<InstallmentPlan>()
-                    //    .GetByCondionAndInclideAsync(p => p.InvoiceId == invoice.Id);
+                        .GetByCondionAndInclideAsync(p => p.InvoiceId == invoice.Id);
 
 
                     if (installmentPlans != null && installmentPlans.Any())
@@ -542,7 +535,7 @@ namespace ErpSystemBeniSouef.Service.CustomerInvoiceServices
                     InvoiceId = invoice.Id,
                     CustomerId = invoice.CustomerId,
                     CollectorId = invoice.Customer.CollectorId,
-                    MonthDate = DateTime.Now.AddMonths(i),
+                    MonthDate = startDate.AddMonths(i),
                     Amount = planAmount,
                     CollectedAmount = 0m,
                     IsDelayed = false
@@ -574,11 +567,8 @@ namespace ErpSystemBeniSouef.Service.CustomerInvoiceServices
         private async Task DeductCommissionForInvoice(CustomerInvoice invoice, int representativeId)
         {
             var commissionRepo = _unitOfWork.Repository<Commission>();
-            var commissions = await commissionRepo.GetAllAsync(c => c.Representative);
-            //var commissions = await commissionRepo.GetAllAsync();
 
-            var commission = commissions
-                .FirstOrDefault(c => c.InvoiceId == invoice.Id && c.RepresentativeId == representativeId);
+            var commission = await commissionRepo.Find(c => c.InvoiceId == invoice.Id && c.RepresentativeId == representativeId);
 
             if (commission != null && !commission.IsDeducted)
             {
@@ -600,14 +590,12 @@ namespace ErpSystemBeniSouef.Service.CustomerInvoiceServices
             {
                 // 1. Get existing invoice with all related data
                 var existingInvoice = await _unitOfWork.Repository<CustomerInvoice>()
-                    .GetAllQueryable(
+                    .FindWithIncludesAsync(
+                        i => i.CustomerId == invoiceId && !i.IsDeleted,
                         i => i.Customer,
                         i => i.Items,
                         i => i.Installments
-                    //,
-                    //i => i.Items.Select(ii => ii.Product)
-                    )
-                    .FirstOrDefaultAsync(i => i.CustomerId == invoiceId && !i.IsDeleted);
+                    );
 
                 if (existingInvoice == null)
                     return ServiceResponse<bool>.Failure("Invoice not found.");
@@ -774,7 +762,7 @@ namespace ErpSystemBeniSouef.Service.CustomerInvoiceServices
             {
                 // Remove related monthly installments
                 var monthlyInstallments = await _unitOfWork.Repository<MonthlyInstallment>()
-                    .GetAllAsync(m => m.InvoiceId == invoice.Id);
+                    .GetByCondionAndInclideAsync(m => m.InvoiceId == invoice.Id);
 
                 foreach (var monthly in monthlyInstallments)
                 {
@@ -795,7 +783,18 @@ namespace ErpSystemBeniSouef.Service.CustomerInvoiceServices
                 };
 
                 _unitOfWork.Repository<InstallmentPlan>().Add(newPlan);
-                await GenerateMonthlyInstallmentsAsync(invoice, inst.NumberOfMonths, inst.Amount, invoice.InvoiceDate);
+
+                var lastInstallment = _unitOfWork.Repository<MonthlyInstallment>()
+                    .GetAllQueryable()
+                    .Where(m => m.InvoiceId == invoice.Id)
+                    .OrderByDescending(m => m.MonthDate)
+                    .FirstOrDefault();
+
+                var startDate = lastInstallment is null
+                    ? invoice.Customer.FirstInvoiceDate
+                    : lastInstallment.MonthDate.AddMonths(1);
+
+                await GenerateMonthlyInstallmentsAsync(invoice, inst.NumberOfMonths, inst.Amount, startDate);
             }
         }
 
@@ -803,7 +802,7 @@ namespace ErpSystemBeniSouef.Service.CustomerInvoiceServices
         private async Task RecalculateInvoiceTotalAsync(CustomerInvoice invoice)
         {
             var items = await _unitOfWork.Repository<CustomerInvoiceItems>()
-                .GetAllAsync(i => i.InvoiceId == invoice.Id);
+                .GetByCondionAndInclideAsync(i => i.InvoiceId == invoice.Id);
 
             decimal itemsTotal = items.Sum(i => i.Quantity * i.Price);
             decimal deposit = invoice.Customer?.Deposit ?? 0;


### PR DESCRIPTION
Implement cascade delete for CustomerInvoice and related entities (items, installments, discounts, commissions) in EF Core model and migrations. Update repository usage for related data loading and fix installment date logic. Adjust Commission relationships to avoid SQL Server multiple cascade path errors using ClientCascade where needed. Update connection string to use local SQL Server instance.